### PR TITLE
Sandland/2 add large file support

### DIFF
--- a/y2025/advantagescope/assets/.gitattributes
+++ b/y2025/advantagescope/assets/.gitattributes
@@ -1,0 +1,3 @@
+*.glb filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.so filter=lfs diff=lfs merge=lfs -text

--- a/y2025/advantagescope/assets/README.txt
+++ b/y2025/advantagescope/assets/README.txt
@@ -1,0 +1,3 @@
+This folder contains extra assets for the odometry, 3D field, and joystick views. For more details, see the "Custom Fields/Robots/Joysticks" page in the AdvantageScope documentation (available through the documentation tab in the app or the URL below).
+
+https://docs.advantagescope.org/more-features/custom-assets

--- a/y2025/advantagescope/assets/Robot_Octobot/config.json
+++ b/y2025/advantagescope/assets/Robot_Octobot/config.json
@@ -1,0 +1,20 @@
+{
+  "name": "9584 Octobot (2025)",
+  "rotations": [
+    {
+      "axis": "y",
+      "degrees": 90
+    },
+    {
+      "axis": "x",
+      "degrees": 90
+    },
+    {
+      "axis": "z",
+      "degrees": 180
+    }
+  ],
+  "position": [0, 0, 0],
+  "cameras": [],
+  "components": []
+}


### PR DESCRIPTION
Fixes #2, and allows us to check in *.glb models needed by AdvantageScope.