### PR TITLE
Add *.glb (AdvantageScope model files) to LFS list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.so filter=lfs diff=lfs merge=lfs -text
 *.so.debug filter=lfs diff=lfs merge=lfs -text
+*.glb filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Fixes #2 by adding support for *.glb files to LFS types